### PR TITLE
Add Windows 10, Edge, and PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This isn't comprehensive feature detection library like https://github.com/Moder
 
 Why use this
 -----------
-We support certain browsers (the main ones) and would like to inform users gently that they aren't supported and things may not work. 
-This doesn't block access. This doesn't hinder the users experience. Simply states that unless they move to a supported browser, we 
+We support certain browsers (the main ones) and would like to inform users gently that they aren't supported and things may not work.
+This doesn't block access. This doesn't hinder the users experience. Simply states that unless they move to a supported browser, we
 can't guarantee a good user experience.
 
 This helps manage expectations for users as well as aids in our support center in diagnosing issues.
@@ -34,10 +34,11 @@ supportedBrowser - This is just a simple function. Given what you want and what 
 
 What are the main ones
 ----------
-Windows xp,vista,7,8
+Windows xp,vista,7,8,10
 * Chrome
 * Firefox
 * Internet Explorer (>=8)
+* Edge
 
 OSX 10.8, 10.9
 * Safari
@@ -46,11 +47,14 @@ OSX 10.8, 10.9
 
 Android
 * Android Browser 2.3 (Gingerbread)
-* Chrome 4.0 (IceCream Sandwhich), 4.1-4.3 (Jelly Bean), 4.4 (KitKat)
-* Firefox 2.3 (Gingerbread), 4.0 (IceCream Sandwhich), 4.1-4.3 (Jelly Bean), 4.4 (KitKat)
+* Chrome 4.0 (Ice Cream Sandwich), 4.1-4.3 (Jelly Bean), 4.4 (KitKat)
+* Firefox 2.3 (Gingerbread), 4.0 (Ice Cream Sandwich), 4.1-4.3 (Jelly Bean), 4.4 (KitKat)
 
 iOS 6/7
 * Safari
+
+Headless Testing
+* PhantomJS
 
 To Use
 -----------

--- a/src/browserInfo.js
+++ b/src/browserInfo.js
@@ -9,11 +9,11 @@
         browser = navigator.appName,                        // browser string [Netscape]
         version = '' + parseFloat(navigator.appVersion),    // version string (5) [5.0 (Windows)]
         majorVersion = parseInt(navigator.appVersion, 10);   // version number (5) [5.0 (Windows)]
-    
+
     var nameOffset, // used to detect other browsers name
         verOffset,  // used to trim out version
         ix;          // used to trim string
-    
+
     // Opera
     if ((verOffset = navUserAgent.indexOf('Opera')) !== -1) {
       browser = 'Opera';
@@ -21,7 +21,7 @@
       if ((verOffset = navUserAgent.indexOf('Version')) !== -1) {
         version = navUserAgent.substring(verOffset + 8);
       }
-    } 
+    }
 
     //MSIE
     else if ((verOffset = navUserAgent.indexOf('MSIE')) !== -1) {
@@ -37,7 +37,13 @@
       if ((verOffset = navUserAgent.indexOf('rv:')) !== -1) {
         version = navUserAgent.substring(verOffset + 3);
       }
-    } 
+    }
+
+    //MS Edge
+    else if ((verOffset = navUserAgent.indexOf('Edge')) !== -1) {
+      browser = 'Microsoft Edge';
+      version = navUserAgent.substring(verOffset + 5);
+    }
 
     // Chrome
     else if ((verOffset = navUserAgent.indexOf('Chrome')) !== -1) {
@@ -48,8 +54,14 @@
     // Chrome on iPad identifies itself as Safari. However it does mention CriOS.
     else if ((verOffset = navUserAgent.indexOf('CriOS')) !== -1) {
       browser = 'Chrome';
-      version = navUserAgent.substring(verOffset + 6);        
-    } 
+      version = navUserAgent.substring(verOffset + 6);
+    }
+
+    //PhantomJS
+    else if ((verOffset = navUserAgent.indexOf('PhantomJS')) !== -1) {
+      browser = 'PhantomJS';
+      version = navUserAgent.substring(verOffset + 10);
+    }
 
     // Safari
     else if ((verOffset = navUserAgent.indexOf('Safari')) !== -1) {
@@ -58,13 +70,13 @@
       if ((verOffset = navUserAgent.indexOf('Version')) !== -1) {
         version = navUserAgent.substring(verOffset + 8);
       }
-    } 
+    }
 
     // Firefox
     else if ((verOffset = navUserAgent.indexOf('Firefox')) !== -1) {
       browser = 'Firefox';
       version = navUserAgent.substring(verOffset + 8);
-    } 
+    }
 
     // Other browsers
     else if ((nameOffset = navUserAgent.lastIndexOf(' ') + 1) < (verOffset = navUserAgent.lastIndexOf('/'))) {
@@ -75,12 +87,10 @@
       }
     }
 
-
     // trim the version string
     if ((ix = version.indexOf(';')) !== -1) version = version.substring(0, ix);
     if ((ix = version.indexOf(' ')) !== -1) version = version.substring(0, ix);
     if ((ix = version.indexOf(')')) !== -1) version = version.substring(0, ix);
-
 
     // why is this here?
     majorVersion = parseInt('' + version, 10);
@@ -151,7 +161,7 @@
           return ret;
         }
       }
-      
+
       for(i = 0; i < phoneStrings.length; i++){
         var phoneString = phoneStrings[i];
         if (phoneStrings[i].r.test(navUserAgent)) {
@@ -160,7 +170,7 @@
           return ret;
         }
       }
-      
+
       if(/Mobile|mini|Fennec|Android/.test(navAppVersion)){
         ret.deviceType = 'mobile';
         return ret;
@@ -171,7 +181,7 @@
     var navAppVersion = navigator.appVersion;
     var navUserAgent = navigator.userAgent;
     // system
-    
+
     var clientStrings = [
       { s: 'Windows 3.11', r: /Win16/ },
       { s: 'Windows 95', r: /(Windows 95|Win95|Windows_95)/ },
@@ -185,6 +195,7 @@
       { s: 'Windows 7', r: /(Windows 7|Windows NT 6.1)/ },
       { s: 'Windows 8.1', r: /(Windows 8.1|Windows NT 6.3)/ },
       { s: 'Windows 8', r: /(Windows 8|Windows NT 6.2)/ },
+      { s: 'Windows 10', r: /(Windows NT 10.0)/ },
       { s: 'Windows NT 4.0', r: /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/ },
       { s: 'Windows ME', r: /Windows ME/ },
       { s: 'Android', r: /Android/ },
@@ -212,7 +223,7 @@
           os = 'Windows';
         }
         else if(os === 'Mac OS X'){
-          osVersion = /Mac OS X (10[\.\_\d]+)/.exec(navUserAgent)[1]; 
+          osVersion = /Mac OS X (10[\.\_\d]+)/.exec(navUserAgent)[1];
         }
         else if(os === 'Android'){
           osVersion = /Android ([\.\_\d]+)/.exec(navUserAgent)[1];
@@ -221,7 +232,7 @@
           osVersion = /OS (\d+)_(\d+)_?(\d+)?/.exec(navAppVersion);
           osVersion = osVersion[1] + '.' + osVersion[2] + '.' + (osVersion[3] | 0);
         }
-      
+
         return {
           name: os,
           versionString: osVersion
@@ -235,7 +246,7 @@
   };
 
   var getBrowserFeatures = function () {
-    
+
       // cookie support
     var cookieEnabled = false;
     try {
@@ -256,7 +267,7 @@
       },
       allowsCookies:cookieEnabled
     };
-  }; 
+  };
 
   var clientInfo = {
     userAgent: navigator.userAgent,
@@ -265,14 +276,14 @@
     device: getDevice(),
     os: getOS()
   };
-  //CommonJS  
+  //CommonJS
   if (typeof require === 'function' && typeof module === 'object' && module && typeof exports === 'object' && exports){
     module.exports = clientInfo;
   }
-  // AMD 
+  // AMD
   else if (typeof define === 'function' && typeof define.amd == 'object'&& define.amd){
     define(function(){
-      return clientInfo; 
+      return clientInfo;
     });
   }
   //Global

--- a/test-site/phantom.js
+++ b/test-site/phantom.js
@@ -1,0 +1,9 @@
+var page = require('webpage').create();
+var browserInfo = require("../src/browserInfo");
+page.open('about:blank', function(status) {
+    console.log("Status: " + status);
+	if (status === "success") {
+		console.log("browserInfo:\n" + JSON.stringify(browserInfo, null, 2));
+	}
+	phantom.exit();
+});


### PR DESCRIPTION
Hello,

I added the regex for Windows 10.

Edge was appearing as Chrome 42, I added a check for the Edge browser before the check for Chrome.
PhantomJS was appearing as Safari 534, I added a check for PhantomJS before the check for Safari.

I added a test script for phantomjs in the test-site directory. It can be run using the command: "phantomjs phantom.js" from the test-site directory.

I updated the Readme to include updated support.

My editor also trimmed trailing white space.

-Mike
