### PR TITLE
Update Mac OS X version regular expression

### DIFF
--- a/src/browserInfo.js
+++ b/src/browserInfo.js
@@ -222,7 +222,7 @@
           os = 'Windows';
         }
         else if(os === 'Mac OS X'){
-          osVersion = /Mac OS X (10[\.\_\d]+)/.exec(navUserAgent)[1];
+          osVersion = /Mac OS X\s?(10[\.\_\d]+)?/.exec(navUserAgent)[1];
         }
         else if(os === 'Android'){
           osVersion = /Android ([\.\_\d]+)/.exec(navUserAgent)[1];

--- a/test-site/phantom.js
+++ b/test-site/phantom.js
@@ -3,6 +3,7 @@ var browserInfo = require("../src/browserInfo");
 page.open('about:blank', function(status) {
     console.log("Status: " + status);
 	if (status === "success") {
+		console.log("UA String:", window.navigator.userAgent);
 		console.log("browserInfo:\n" + JSON.stringify(browserInfo, null, 2));
 	}
 	phantom.exit();


### PR DESCRIPTION
We were receiving an error in Phantom JS on Mac OS X because the regular expression to find the version assumed that the version would always exist in the UA string after Mac OS X, but in Phantom JS it only reports the OS and not the version.

Here's an example UA string from PhantomJS on OSX:
Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.0.0 (development) Safari/538.1

The old regular expression failed to find a match because there was no " 10..." after Mac OS X, so the exec returned null. When trying to get the index [1] JavaScript threw an error that it couldn't get index 1 of null.

The updated regular expression resolves this issue by always return an array, even if it just contains ["Mac OS X"]. When checking for index 1 of an array of only one element javascript will just return null. The result for PhantomJS is that the versionString will not be included in window.clientInfo.os for OSX.
